### PR TITLE
Remove SYSTEM_ALERT_WINDOW permission and clean up unused imports

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.elriztechnology.flutter_presentation_display">
-
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 </manifest>

--- a/android/src/main/kotlin/com/elriztechnology/flutter_presentation_display/FlutterPresentationDisplayPlugin.kt
+++ b/android/src/main/kotlin/com/elriztechnology/flutter_presentation_display/FlutterPresentationDisplayPlugin.kt
@@ -140,7 +140,6 @@ class FlutterPresentationDisplayPlugin : FlutterPlugin, ActivityAware, MethodCha
         }
     }
 
-
     private fun transferDataToPresentation(call: MethodCall, result: MethodChannel.Result) {
         try {
             flutterEngineChannel?.invokeMethod("transferDataToPresentation", call.arguments)

--- a/android/src/main/kotlin/com/elriztechnology/flutter_presentation_display/PresentationDisplay.kt
+++ b/android/src/main/kotlin/com/elriztechnology/flutter_presentation_display/PresentationDisplay.kt
@@ -11,8 +11,6 @@ import io.flutter.embedding.android.FlutterView
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodChannel
-import android.view.WindowManager
-import android.os.Build
 
 class PresentationDisplay(
     context: Context,
@@ -31,15 +29,6 @@ class PresentationDisplay(
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val windowType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
-        } else {
-            @Suppress("DEPRECATION")
-            WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY
-        }
-        
-        window?.setType(windowType)
-        
         super.onCreate(savedInstanceState)
 
         val container = FrameLayout(context).apply {


### PR DESCRIPTION
Overlay windows method doesn't work for Sunmi dual screen devices anymore. 

- PresentationDisplay onCreate method replaced with the previous codebase.
- Removed SYSTEM_ALERT_WINDOW permission from AndroidManifest.